### PR TITLE
Use :repositories in project.clj instead of :deploy-repositories

### DIFF
--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -7,10 +7,10 @@
   :scm {:name "git"
         :url "https://github.com/kirasystems/doo"}
 
-  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
-                                    :sign-releases false
-                                    :username :env
-                                    :password :env}]]
+  :repositories [["releases" {:url "https://clojars.org/repo"
+                              :sign-releases false
+                              :username :env
+                              :password :env}]]
 
   :eval-in-leiningen true
 


### PR DESCRIPTION
Apparently credentials as environment variables is only supported by
the :repositories key.