### PR TITLE
Update the logic for selecting exit function

### DIFF
--- a/library/src/doo/runner.cljs
+++ b/library/src/doo/runner.cljs
@@ -13,12 +13,6 @@
   (set! cljs.core.*print-fn* f))
 
 ;; ======================================================================
-;; Node
-
-(defn node? []
-  (exists? js/process))
-
-;; ======================================================================
 ;; Karma Helpers
 
 (defn karma? []
@@ -41,14 +35,13 @@
   (set! *exit-fn* f))
 
 (defn exit! [success?]
-  (if (node?)
-    (let [process-exit (gobj/get js/process "exit")]
-      (process-exit (if success? 0 1)))
-    (try
-      (*exit-fn* success?)
-      (catch :default e
-        (println "WARNING: doo's exit function was not properly set")
-        (println e)))))
+  (try
+    (if-let [nodejs-exit (and (exists? js/process) (gobj/get js/process "exit"))]
+      (nodejs-exit (if success? 0 1))
+      (*exit-fn* success?))
+    (catch :default e
+      (println "WARNING: doo's exit function was not properly set")
+      (println e))))
 
 (defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
   (exit! (successful? m)))


### PR DESCRIPTION
With ClojureScript 1.9.473, Doo will fail to run our tests in `phantomjs` because of this issue. Bringing [the original PR](https://github.com/bensu/doo/pull/141) into our fork so that we can get our tests running in CI.

Speaking of CI... when I set up the `.travis.yml` for this fork, I intentionally set it up to only build the Lein plugin, and not the library. This change affects the library, so we'll have to build (and release) both. Need to look into that.