### PR TITLE
Build doo library as well as lein-doo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: clojure
-before_install: cd plugin
-install: lein install
-script: lein test
+install: cd library && lein install && cd ../plugin && lein install && cd ..
+script: cd plugin && lein test && cd ..
 deploy:
   skip_cleanup: true
   provider: script
-  script: lein deploy
+  script: cd library && lein deploy && cd ../plugin && lein deploy && cd ..
   on:
     tags: true
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased -
 
+## [0.1.9] - 2017-09-20
+
+### Fixed
+- Bug where exiting the test process failed on some environments,
+  thanks to @loomis
+
 ## [0.1.8] - 2017-09-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # doo
 
-[![Circle CI](https://circleci.com/gh/bensu/doo.svg?style=svg)](https://circleci.com/gh/bensu/doo)
-[![Build status](https://ci.appveyor.com/api/projects/status/ufuprdbgn5afhudt?svg=true)](https://ci.appveyor.com/project/bensu/doo)
-
 A library and Leiningen plugin to run `cljs.test` in many JS environments.
 
 >  ...and I would have gotten away with it, too, if it wasn't for you meddling kids.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A library and Leiningen plugin to run `cljs.test` in many JS environments.
 
 This README is for the latest stable release:
 
-`[kirasystems/lein-doo "0.1.8"]`
+`[kirasystems/lein-doo "0.1.9"]`
 
 To use doo you need to use `[org.clojure/clojurescript "0.0-3308"]` or
 newer.

--- a/README_STABLE.md
+++ b/README_STABLE.md
@@ -1,7 +1,5 @@
 # doo
 
-[![Circle CI](https://circleci.com/gh/bensu/doo.svg?style=svg)](https://circleci.com/gh/bensu/doo)
-
 A library and Leiningen plugin to run `cljs.test` in many JS environments.
 
 >  ...and I would have gotten away with it, too, if it wasn't for you meddling kids.

--- a/library/project.clj
+++ b/library/project.clj
@@ -1,4 +1,4 @@
-(defproject kirasystems/doo "0.1.7"
+(defproject kirasystems/doo "0.1.9"
   :description "doo is a library to run clj.test on different js environments."
   :url "https://github.com/kirasystems/doo"
   :license {:name "Eclipse Public License"

--- a/library/project.clj
+++ b/library/project.clj
@@ -1,11 +1,11 @@
-(defproject doo "0.1.7"
+(defproject kirasystems/doo "0.1.7"
   :description "doo is a library to run clj.test on different js environments."
-  :url "https://github.com/bensu/doo"
+  :url "https://github.com/kirasystems/doo"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :scm {:name "git"
-        :url "https://github.com/bensu/doo"}
+        :url "https://github.com/kirasystems/doo"}
 
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :sign-releases false

--- a/library/project.clj
+++ b/library/project.clj
@@ -7,7 +7,10 @@
   :scm {:name "git"
         :url "https://github.com/bensu/doo"}
 
-  :deploy-repositories [["clojars" {:creds :gpg}]]
+  :repositories [["releases" {:url "https://clojars.org/repo"
+                              :sign-releases false
+                              :username :env
+                              :password :env}]]
 
   :test-paths ["test/clj"]
 
@@ -23,4 +26,13 @@
 
   :profiles
   {:dev {:source-paths ["src/clj" "test/clj" "../example/src" "../example/test"]
-         :dependencies [[org.clojure/core.async "0.1.346.0-17112a-alpha"]]}})
+         :dependencies [[org.clojure/core.async "0.1.346.0-17112a-alpha"]]}}
+
+  ;;; Don't sign the tag, and don't deploy
+  :release-tasks [["vcs" "assert-committed"]
+                  ["change" "version" "leiningen.release/bump-version" "release"]
+                  ["vcs" "commit"]
+                  ["vcs" "tag" "--no-sign"]
+                  ["change" "version" "leiningen.release/bump-version"]
+                  ["vcs" "commit"]
+                  ["vcs" "push"]])

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject kirasystems/lein-doo "0.1.8"
+(defproject kirasystems/lein-doo "0.1.9"
   :description "lein-doo is a plugin to run clj.test on different js environments."
   :url "https://github.com/kirasystems/doo"
   :license {:name "Eclipse Public License"
@@ -15,7 +15,7 @@
   :eval-in-leiningen true
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [doo "0.1.7"]]
+                 [kirasystems/doo "0.1.9"]]
 
   :test-paths ["test/clj" "test/cljs"]
 


### PR DESCRIPTION
In #5, a bugfix was applied to the `doo` library. The current `.travis.yml` doesn't touch the library at all, and I hadn't added the groupID there or anything, so that all needed to be addressed.

I made a couple of important decisions here:

1. Skipped over version `0.1.8` for the library. `0.1.8` for the plugin has already been released using `0.1.7` of the library, so we need to bump the plugin version anyway. It was clearly intentional to keep the two in sync, so that's what we'll do going forward. Might need a script to speed up updating the number wherever it shows up, though.
2. Tests aren't run for the `doo` library in Travis. This is very different from the original repo, which has a very thorough [CircleCI build](https://github.com/kirasystems/doo/blob/travis-build-library-too/circle.yml) testing a ton of different environments, and a more minimal [AppVeyor build](https://github.com/kirasystems/doo/blob/travis-build-library-too/appveyor.yml). There are external dependencies for each browser environment, and since we'd like to hope this fork won't be a long running project, it didn't seem worth the extra effort to set up.