### PR TITLE
lein-doo plugin now downloads latest forked doo library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased -
 
+## [0.1.10] - 2017-09-20
+
+### Fixed
+- Bug where `lein-doo` plugin was still downloading official `doo` releases
+
 ## [0.1.9] - 2017-09-20
 
 ### Fixed

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+
+**Review Checklist:**
+
+- Did you update the version for the `doo` library?
+- Did you update the version for the `lein-doo` plugin?
+- Did you update the [version of `doo` that `lein-doo` depends on](https://github.com/kirasystems/doo/blob/master/plugin/project.clj#L18)?
+- Did you update the [call to `leinjacker`](https://github.com/kirasystems/doo/blob/master/plugin/src/leiningen/doo.clj#L206) so it adds the latest?
+- Did you update the CHANGELOG.md?
+- Did you update the [README.md to list the latest version](https://github.com/kirasystems/doo/blame/master/README.md#L9)?

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A library and Leiningen plugin to run `cljs.test` in many JS environments.
 
 This README is for the latest stable release:
 
-`[kirasystems/lein-doo "0.1.9"]`
+`[kirasystems/lein-doo "0.1.10"]`
 
 To use doo you need to use `[org.clojure/clojurescript "0.0-3308"]` or
 newer.

--- a/library/project.clj
+++ b/library/project.clj
@@ -1,4 +1,4 @@
-(defproject kirasystems/doo "0.1.9"
+(defproject kirasystems/doo "0.1.10"
   :description "doo is a library to run clj.test on different js environments."
   :url "https://github.com/kirasystems/doo"
   :license {:name "Eclipse Public License"

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject kirasystems/lein-doo "0.1.9"
+(defproject kirasystems/lein-doo "0.1.10"
   :description "lein-doo is a plugin to run clj.test on different js environments."
   :url "https://github.com/kirasystems/doo"
   :license {:name "Eclipse Public License"
@@ -15,7 +15,7 @@
   :eval-in-leiningen true
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [kirasystems/doo "0.1.9"]]
+                 [kirasystems/doo "0.1.10"]]
 
   :test-paths ["test/clj" "test/cljs"]
 

--- a/plugin/src/leiningen/doo.clj
+++ b/plugin/src/leiningen/doo.clj
@@ -203,7 +203,7 @@ in project.clj.\n")
          ;; FIX: get the version dynamically
          project' (-> project
                       correct-builds
-                      (add-dep ['doo "0.1.7"]))
+                      (add-dep ['kirasystems/doo "0.1.10"]))
          {:keys [source-paths compiler]}
          (cli->build cli project' opts)]
      (doo/assert-alias alias js-envs (:alias opts))


### PR DESCRIPTION
Version 0.1.9 of `kirasystems/lein-doo` was still downloading `doo` 0.1.7, even though its `:dependencies` had been updated. Apparently this call to `leinjacker` overrides that value.

When increasing versions in the future, we'll have to remember to update all these different things. Or work on resolving that "todo: don't hardcode the version" comment.